### PR TITLE
Detect over multiple lines, not just the first

### DIFF
--- a/ftdetect/logstash.vim
+++ b/ftdetect/logstash.vim
@@ -1,7 +1,10 @@
 fun! s:DetectLogstash()
-    if getline(1) =~ '^[ \t]*\(input\|filter\|output\) {'
-        set ft=logstash
-    endif
+    for i in range(10)
+        if getline(i) =~ '^[ \t]*\(input\|filter\|output\) {'
+            set ft=logstash
+            break
+        endif
+    endfor
 endfun
 
 autocmd BufNewFile,BufRead *.conf call s:DetectLogstash()


### PR DESCRIPTION
Useful for when you have comments at the top of the file which e.g.
explains what this specific config does.
