### PR TITLE
skip comment lines when detecting filetype

### DIFF
--- a/ftdetect/logstash.vim
+++ b/ftdetect/logstash.vim
@@ -1,9 +1,20 @@
 fun! s:DetectLogstash()
+	"skip comment lines
+	let lnr = line(".")
+	let this_line = getline(lnr)
+	while (this_line =~ '^#')
+		let lnr = lnr+1
+		let this_line = getline(lnr)
+	endwhile
+
+	"look for keywords in next 10 lines
     for i in range(10)
-        if getline(i) =~ '^[ \t]*\(input\|filter\|output\) {'
+        if (this_line =~ '^[ \t]*\(input\|filter\|output\) {')
             set ft=logstash
             break
         endif
+		let lnr = lnr + 1
+		let this_line = getline(lnr)
     endfor
 endfun
 


### PR DESCRIPTION
Made some changes to the ftdetect script, so that comment lines in the beginning of the file are skipped, before looking for the logstash keywords.