### PR TITLE
remove iskeyword settings

### DIFF
--- a/syntax/logstash.vim
+++ b/syntax/logstash.vim
@@ -5,10 +5,6 @@ if exists("b:current_syntax")
   finish
 end
 
-setlocal iskeyword+=.
-setlocal iskeyword+=/
-setlocal iskeyword+=:
-
 syn match logstashVariableBlock '\v\[[^,"].*\]' contained
 syn match logstashVariableString '\v\[[^,"].*\]' contained
 


### PR DESCRIPTION
Remove "iskeyword" settings so that text object works as expected.

Set ". / :" to "iskeyword" will let them be regarded as a part of a word. For example when 'ciw' entered,  the whole path is deleted because '/', ':', and '.' are not a separator anymore. 